### PR TITLE
ci: remove NPM_TOKEN from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_NPM_MATTERLABS_AUTOMATION_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_NPM_MATTERLABS_AUTOMATION_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Removes the npm publish token references from the CI workflow(s).

Per request, all npm token auth is dropped:
- the `NPM_TOKEN` env var
- `NODE_AUTH_TOKEN` sourced from the same npm secret
- the `token:` secret passed into the reusable publish workflow (where applicable)

Note: with the token gone, the publish step will no longer authenticate to npm via token. If automated publishing should continue, configure npm Trusted Publishing (OIDC) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)